### PR TITLE
host parsing

### DIFF
--- a/js/bigdesk.js
+++ b/js/bigdesk.js
@@ -61,7 +61,7 @@
             if (!hostVal || !portVal || hostVal.trim().length == 0 || portVal.trim().length == 0) {
                 alert("Fill in host and port data!");
             } else {
-                endpoint();
+                setupEndpoint();
                 connect();
             }
         }
@@ -97,7 +97,7 @@
      * @todo Support scheme.
      * @todo Use some sort of parse_uri()
      */
-    function endpoint() {
+    function setupEndpoint() {
         if (host.val().indexOf('/') != -1) {
             var hostArr = host.val().split('/');
 


### PR DESCRIPTION
Hey,

so in our case, the public interface to elasticsearch runs behind a proxy at http://server:port/foo. I extended your code to generate the correct endpoint. In the end, I think, the fields should be merged to allow `host:port/whatever` style and to omit the parsing in JavaScript.

I also plan to add support for other schemes (`http` vs `https`). Let me know if you'd like me to add this before you merge.

Till
