### PR TITLE
Add query string parameters for automatically connecting to a particular host

### DIFF
--- a/README.textile
+++ b/README.textile
@@ -26,3 +26,4 @@ On top of that it is possible to set refresh interval and time window for the ch
 
 Supports elasticsearch 0.17.x and 0.18.x
 
+To immediately connect to a particular host, add the <code>host</code>, <code>port</code>, and <code>go</code> parameters to the query string: <code>index.html?host=search.example.com&port=9200&go</code>

--- a/index.html
+++ b/index.html
@@ -297,6 +297,7 @@
 <script src="js/lib/mustache/mustache.js" type="text/javascript" charset="utf-8"></script>
 <script src="js/lib/jQueryMustache/jQueryMustache.js" type="text/javascript" charset="utf-8"></script>
 <script src="js/lib/highcharts/highcharts.js" type="text/javascript" charset="utf-8"></script>
+<script src="js/lib/parseUri/parseuri.js" type="text/javascript" charset="utf-8"></script>
 <script src="js/charts.js" type="text/javascript" charset="utf-8"></script>
 <script src="js/bigdesk.js" type="text/javascript" charset="utf-8"></script>
 

--- a/js/bigdesk.js
+++ b/js/bigdesk.js
@@ -87,6 +87,20 @@
         redrawCharts(charts);
     });
 
+    parsedUri = parseUri(document.location.href);
+
+    if (typeof parsedUri.queryKey.host !== 'undefined') {
+        host.val(parsedUri.queryKey.host);
+    }
+
+    if (typeof parsedUri.queryKey.port !== 'undefined') {
+        port.val(parsedUri.queryKey.port);
+    }
+
+    if (typeof parsedUri.queryKey.go !== 'undefined') {
+        button.click();
+    }
+
     // build all charts
     charts = [
         // process chart

--- a/js/lib/parseUri/parseuri.js
+++ b/js/lib/parseUri/parseuri.js
@@ -1,0 +1,32 @@
+// parseUri 1.2.2
+// (c) Steven Levithan <stevenlevithan.com>
+// MIT License
+
+function parseUri (str) {
+	var	o   = parseUri.options,
+		m   = o.parser[o.strictMode ? "strict" : "loose"].exec(str),
+		uri = {},
+		i   = 14;
+
+	while (i--) uri[o.key[i]] = m[i] || "";
+
+	uri[o.q.name] = {};
+	uri[o.key[12]].replace(o.q.parser, function ($0, $1, $2) {
+		if ($1) uri[o.q.name][$1] = $2;
+	});
+
+	return uri;
+};
+
+parseUri.options = {
+	strictMode: false,
+	key: ["source","protocol","authority","userInfo","user","password","host","port","relative","path","directory","file","query","anchor"],
+	q:   {
+		name:   "queryKey",
+		parser: /(?:^|&)([^&=]*)=?([^&]*)/g
+	},
+	parser: {
+		strict: /^(?:([^:\/?#]+):)?(?:\/\/((?:(([^:@]*)(?::([^:@]*))?)?@)?([^:\/?#]*)(?::(\d*))?))?((((?:[^?#\/]*\/)*)([^?#]*))(?:\?([^#]*))?(?:#(.*))?)/,
+		loose:  /^(?:(?![^:@]+:[^:@\/]*@)([^:\/?#.]+):)?(?:\/\/)?((?:(([^:@]*)(?::([^:@]*))?)?@)?([^:\/?#]*)(?::(\d*))?)(((\/(?:[^?#](?![^?#\/]*\.[^?#\/.]+(?:[?#]|$)))*\/?)?([^?#\/]*))(?:\?([^#]*))?(?:#(.*))?)/
+	}
+};


### PR DESCRIPTION
To immediately connect to a particular host, add the host, port, and go parameters to the query string: index.html?host=search.example.com&port=9200&go

Includes the parseUri library from http://blog.stevenlevithan.com/archives/parseuri (MIT).
