### PR TITLE
node stats endpoint fix for 0.19.0: all=true. Ignored pre-0.19.0

### DIFF
--- a/js/bigdesk.js
+++ b/js/bigdesk.js
@@ -488,7 +488,7 @@
 
     function setupInterval (delay) {
         clearInterval(timer);
-        var path = endpoint + "/_cluster/nodes/stats";
+        var path = endpoint + "/_cluster/nodes/stats?all=true";
         var _function = function(){
             $.ajax({
                 type: "GET",


### PR DESCRIPTION
bigdesk.js update :491. Adds ?all=true to nodes/stats endpoint for 0.19 compatibility. Should be backwards compatible as 0.18 ignores the new param.
