### PR TITLE
Update filter cache stats for latest stats API

### DIFF
--- a/js/charts/bigdesk_charts.js
+++ b/js/charts/bigdesk_charts.js
@@ -813,7 +813,7 @@ bigdesk_charts.indicesCacheSize = {
         return stats.map(function(snapshot){
             return {
                 timestamp: +snapshot.id,
-                value: +snapshot.node.indices.cache.filter_size_in_bytes
+                value: +snapshot.node.indices.filter_cache.memory_size_in_bytes
             }
         })
     }
@@ -847,7 +847,7 @@ bigdesk_charts.indicesCacheEvictions = {
         return stats.map(function(snapshot){
             return {
                 timestamp: +snapshot.id,
-                value: +snapshot.node.indices.cache.filter_evictions
+                value: +snapshot.node.indices.filter_cache.evictions
             }
         })
     }

--- a/js/views/SelectedClusterNodeView.js
+++ b/js/views/SelectedClusterNodeView.js
@@ -585,8 +585,8 @@ var SelectedClusterNodeView = Backbone.View.extend({
 
                         try { chart_indicesCacheSize.animate(animatedCharts).update(indices_cache_field_size, indices_cache_filter_size); } catch (ignore) {}
 
-                        if (stats_the_latest.node && stats_the_latest.node.indices && stats_the_latest.node.indices.cache) {
-                            $("#indices_filter_cache_size").text(stats_the_latest.node.indices.cache.filter_size);
+                        if (stats_the_latest.node && stats_the_latest.node.indices && stats_the_latest.node.indices.filter_cache) {
+                            $("#indices_filter_cache_size").text(stats_the_latest.node.indices.filter_cache.memory_size);
                             $("#indices_field_cache_size").text(stats_the_latest.node.indices.fielddata.memory_size);
                         } else {
                             $("#indices_filter_cache_size").text("n/a");
@@ -608,7 +608,7 @@ var SelectedClusterNodeView = Backbone.View.extend({
 
                             try { chart_indicesCacheEvictions.animate(animatedCharts).update(indices_cache_field_evictions, indices_cache_filter_evictions); } catch (ignore) {}
 
-                            $("#indices_filter_cache_evictions").text(stats_the_latest.node.indices.cache.filter_evictions);
+                            $("#indices_filter_cache_evictions").text(stats_the_latest.node.indices.filter_cache.evictions);
                             $("#indices_field_cache_evictions").text(stats_the_latest.node.indices.fielddata.evictions);
 
                         }


### PR DESCRIPTION
The cache size and cache evictions graphs aren't showing up on master because the stats API changed the "cache" field to "filter_cache". This PR updates the appropriate references, so the graphs are now working again (well, locally for me :).
