### PR TITLE
Used `/_nodes` instead of `/_cluster/nodes` for 1.0 compatibility

### DIFF
--- a/js/models/cluster/NodeInfo.js
+++ b/js/models/cluster/NodeInfo.js
@@ -22,7 +22,7 @@
 var NodeInfo = Backbone.Model.extend({
 
     url: function() {
-        return '/_cluster/nodes/' + this.get("nodeId") + '?all=true';
+        return '/_nodes/' + this.get("nodeId") + '?all=true';
     },
 
     validate: function(attrs) {


### PR DESCRIPTION
The `_nodes` endpoint works on both 1.0 and 0.90 versions:

curl 'localhost:9200/_nodes/?all&pretty'
