### PR TITLE
Extract the cluster status CSS and make it more readable

### DIFF
--- a/css/bigdesk.css
+++ b/css/bigdesk.css
@@ -113,6 +113,21 @@ h3 {
     /*background: url("../images/award_star_gold.png") no-repeat 1px 3px;*/
 }
 
+.clusterStatus {
+  padding: 1px 2px;
+}
+.clusterStatus.red {
+  background-color: red;
+  color: white;
+}
+.clusterStatus.yellow {
+  background-color: yellow;
+}
+.clusterStatus.green {
+  background-color: green;
+  color: white;
+}
+
 /* TODO css for chart, move it into different file */
 .line {
     fill: none;

--- a/js/views/ClusterHealthView.js
+++ b/js/views/ClusterHealthView.js
@@ -52,7 +52,7 @@ var ClusterHealthView = Backbone.View.extend({
             $(this.el).html(
                 "Cluster: " + health.get("cluster_name") +
                 "<br>Number of nodes: " + health.get("number_of_nodes") +
-                "<br>Status: <span style='background-color: "+health.get("status")+"'>" + health.get("status") +"</span>");
+                "<br>Status: <span class='clusterStatus " + health.get("status") + "'>" + health.get("status") +"</span>");
         }
         return this;
     },


### PR DESCRIPTION
Hi, I've found that the cluster status indicator was not very readable so I've extracted the style to the CSS file and enhanced it a little bit.

I hope you'll find it better too.
