### PR TITLE
Increase cluster state view circle size

### DIFF
--- a/js/views/ClusterStateView.js
+++ b/js/views/ClusterStateView.js
@@ -107,8 +107,8 @@ var ClusterStateView = Backbone.View.extend({
 
 //                console.log("pack", packData);
 
-                var width = 400,
-                    height = 400,
+                var width = 600,
+                    height = 600,
                     format = d3.format(",d"),
                     span = 5;
 


### PR DESCRIPTION
The circle is too small. 400px is tiny compared to large monitor resolutions.

And small size makes text truncated.
