### PR TITLE
Added plugin-descriptor.properties

### DIFF
--- a/plugin-descriptor.properties
+++ b/plugin-descriptor.properties
@@ -1,0 +1,4 @@
+description=head - Live charts and statistics for Elasticsearch cluster.
+version=master
+site=true
+name=head


### PR DESCRIPTION
I have added `plugin-descriptor.properties` file to avoid installation error on windows 7 - elasticsearch 2.1.0
